### PR TITLE
fix: Change login button to a link element

### DIFF
--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -74,11 +74,15 @@ export default function LoginButton() {
   }
 
   return (
-    <button
-      onClick={handleSignIn}
-      className="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500"
+    <a
+      href="#"
+      onClick={(e) => {
+        e.preventDefault();
+        handleSignIn();
+      }}
+      className="inline-block rounded-full bg-blue-600 px-4 py-2 text-center text-sm font-medium text-white hover:bg-blue-500"
     >
       Sign in with Google
-    </button>
+    </a>
   );
 }


### PR DESCRIPTION
This commit attempts to fix a bug where the 'Sign in with Google' button was not responding to clicks in the deployed environment.

Based on user feedback and as a debugging step, the `<button>` element in `LoginButton.tsx` has been replaced with an `<a>` tag, styled to look identical to the original button.

The `onClick` handler is preserved, preventing the link's default navigation and calling the same `handleSignIn` function. This change in the underlying HTML element may resolve a subtle issue with how the browser attaches or fires the click event listener during React hydration.